### PR TITLE
Fixes BC break from 1.0.8

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -28,7 +28,8 @@ export default () => {
             setMessages: (state, messages) => {
                 messages.map(message => {
                     message.timestamp = moment(message.timestamp).toISOString();
-                    message.myself = message.participantId === state.myself.id;
+                    if (!("myself" in message))
+                        message.myself = message.participantId === state.myself.id;
                 });
                 state.messages = messages;
             },


### PR DESCRIPTION
Fixes the BC break that appeared from commit f52a49247b2d8e975a5a17459fd8031540d45c80

As in my use case myself can have a different id than the one set in messages but still be from myself